### PR TITLE
Feature add effector admin

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,4 +1,4 @@
 {
   "editor.formatOnSave": true,
-  "eslint.autoFixOnSave": true
+  "eslint.autoFixOnSave": true,
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,39 @@
 import React from 'react'
 import './App.css'
 import { Routes, Route } from 'react-router-dom'
-import { AdminLoginPage } from './components/AdminLoginPage/AdminLoginPage'
-import { AdminPage } from './components/AdminPage/AdminPage'
+import { AdminLoginPage } from 'src/components/AdminLoginPage'
+import { AdminPage } from 'src/components/AdminPage'
+import { NavigationPageTypesEnum } from './constants'
 
 const App = () => {
   return (
     <div className="App">
       <Routes>
-        <Route path="/" element={<div>Ведомость школы JS</div>} />
-        <Route path="/login" element={<div>login</div>} />
         <Route
-          path="/admin-login"
+          path={NavigationPageTypesEnum.homePage}
+          element={<div>Ведомость школы JS</div>}
+        />
+        <Route
+          path={NavigationPageTypesEnum.loginPage}
+          element={<div>login</div>}
+        />
+        <Route
+          path={NavigationPageTypesEnum.adminLoginPage}
           element={
             <div>
               <AdminLoginPage />
             </div>
           }
         />
-        <Route path="/student" element={<div>student</div>} />
         <Route
-          path="/admin"
+          path={NavigationPageTypesEnum.studentPage}
+          element={<div>student</div>}
+        />
+        <Route
+          path={NavigationPageTypesEnum.adminPage}
           element={
             <div>
-              <AdminPage isAdmin />
+              <AdminPage />
             </div>
           }
         />

--- a/src/components/AdminLoginPage/AdminLoginPage.tsx
+++ b/src/components/AdminLoginPage/AdminLoginPage.tsx
@@ -1,25 +1,40 @@
 import { useNavigate } from 'react-router-dom'
-import { useState } from 'react'
-import { checkIsAdmin } from '../../utils/checkIsAdmin'
+import { useStore } from 'effector-react'
+import { checkIsAdmin } from 'src/utils/checkIsAdmin'
 import { Form, Input, Button, Alert, Space } from 'antd'
-import { LoginCheck } from '../../interfaces'
+import { LoginCheck } from 'src/interfaces'
+import {
+  CurrentRoleTypesEnum,
+  setCurrentRoleEvent,
+} from '../../store/currentRole'
+import {
+  $displayErrorWarning,
+  setErrorWarningEvent,
+} from '../../store/errorWidget'
+import { adminLoginMessageTypesEnum } from './constants'
+import { NavigationPageTypesEnum } from '../../constants'
 
 export const AdminLoginPage = () => {
-  //TODO перенести в эффектор
-  const [isError, setIsError] = useState(false)
-
   const navigate = useNavigate()
+  const errorWarningMessage = useStore($displayErrorWarning)
+
   const handleFinish = (values: LoginCheck) => {
-    checkIsAdmin({ ...values }) ? navigate('/admin') : setIsError(true)
+    if (checkIsAdmin({ ...values })) {
+      setCurrentRoleEvent(CurrentRoleTypesEnum.admin)
+      navigate(NavigationPageTypesEnum.adminPage)
+    }
+    setErrorWarningEvent()
   }
 
   const handleFinishFailed = () => {
-    setIsError(true)
+    setErrorWarningEvent()
   }
 
   return (
     <Space direction="vertical" size={32}>
-      {isError && <Alert message="Неверный логин или пароль!" type="error" />}
+      {errorWarningMessage && (
+        <Alert message={adminLoginMessageTypesEnum.incorrect} type="error" />
+      )}
 
       <Form
         name="basic"
@@ -39,7 +54,7 @@ export const AdminLoginPage = () => {
           rules={[
             {
               required: true,
-              message: 'Введите логин!',
+              message: `${adminLoginMessageTypesEnum.loginIsEmpty}`,
             },
           ]}
         >
@@ -52,7 +67,7 @@ export const AdminLoginPage = () => {
           rules={[
             {
               required: true,
-              message: 'Введите пароль!',
+              message: `${adminLoginMessageTypesEnum.passwordIsEmpty}`,
             },
           ]}
         >

--- a/src/components/AdminLoginPage/constants.ts
+++ b/src/components/AdminLoginPage/constants.ts
@@ -1,0 +1,5 @@
+export enum adminLoginMessageTypesEnum {
+  incorrect = 'Неверный логин или пароль!',
+  loginIsEmpty = 'Введите логин!',
+  passwordIsEmpty = 'Введите пароль!',
+}

--- a/src/components/AdminLoginPage/index.ts
+++ b/src/components/AdminLoginPage/index.ts
@@ -1,0 +1,1 @@
+export * from './AdminLoginPage'

--- a/src/components/AdminPage/AdminPage.tsx
+++ b/src/components/AdminPage/AdminPage.tsx
@@ -1,9 +1,13 @@
+import { FC } from 'react'
 import { Space } from 'antd'
-import { AdminPageForm } from './components/AdminPanelForm'
-import { ErrorPage } from '../ErrorPage/ErrorPage'
-import { AdminPageProps } from '../../interfaces'
+import { useStore } from 'effector-react'
+import { AdminPageForm } from './components/AdminPageForm'
+import { ErrorPage } from '../ErrorPage'
+import { $accessByRole } from 'src/store/currentRole'
+import { adminFormTypesEnum } from './constants'
 
-export const AdminPage = ({ isAdmin }: AdminPageProps) => {
+export const AdminPage: FC = () => {
+  const { isAdmin } = useStore($accessByRole)
   if (!isAdmin) {
     return <ErrorPage />
   }
@@ -11,10 +15,13 @@ export const AdminPage = ({ isAdmin }: AdminPageProps) => {
   return (
     <>
       <Space direction="vertical" size={80}>
-        <AdminPageForm title="Преподаватели" placeholder="Ник на Github" />
         <AdminPageForm
-          title="Имена репозиториев"
-          placeholder="Имя репозитория"
+          title={adminFormTypesEnum.teacherFormTitle}
+          placeholder={adminFormTypesEnum.teacherFormPlaceholder}
+        />
+        <AdminPageForm
+          title={adminFormTypesEnum.repositoryFormTitle}
+          placeholder={adminFormTypesEnum.repositoryFormPlaceholder}
         />
       </Space>
     </>

--- a/src/components/AdminPage/components/AdminPageForm.tsx
+++ b/src/components/AdminPage/components/AdminPageForm.tsx
@@ -1,12 +1,19 @@
+import { FC } from 'react'
 import { Form, Input, Button, Space, Typography } from 'antd'
 import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons'
-import { AdminPanelFormProps } from '../../../interfaces'
+import { AdminPanelFormProps } from 'src/interfaces'
 import { StoreValue } from 'rc-field-form/lib/interface'
+import { HandleFinishProps } from './interfaces'
+import { ButtonTextTypesEnum } from 'src/constants'
+import { adminFormMessageTypesEnum } from './constants'
 
 const { Title } = Typography
 
-export const AdminPageForm = ({ title, placeholder }: AdminPanelFormProps) => {
-  const onFinish = (values: { value: string }[]) => {
+export const AdminPageForm: FC<AdminPanelFormProps> = ({
+  title,
+  placeholder,
+}) => {
+  const handleFinish = (values: HandleFinishProps) => {
     //TODO полученные значения надо передавать в БД, console.log удалить
     console.log('Received values of form:', values)
   }
@@ -21,7 +28,11 @@ export const AdminPageForm = ({ title, placeholder }: AdminPanelFormProps) => {
       method(value)
 
   return (
-    <Form name="dynamic_form_nest_item" onFinish={onFinish} autoComplete="off">
+    <Form
+      name="dynamic_form_nest_item"
+      onFinish={handleFinish}
+      autoComplete="off"
+    >
       <Title level={2}>{title}</Title>
       <Form.List name="users">
         {(fields, { add, remove }) => (
@@ -35,7 +46,12 @@ export const AdminPageForm = ({ title, placeholder }: AdminPanelFormProps) => {
                 <Form.Item
                   {...restField}
                   name={[name, 'value']}
-                  rules={[{ required: true, message: 'Ввeдите значение' }]}
+                  rules={[
+                    {
+                      required: true,
+                      message: adminFormMessageTypesEnum.emptyValue,
+                    },
+                  ]}
                 >
                   <Input placeholder={placeholder} />
                 </Form.Item>
@@ -59,7 +75,7 @@ export const AdminPageForm = ({ title, placeholder }: AdminPanelFormProps) => {
       </Form.List>
       <Form.Item>
         <Button type="primary" htmlType="submit">
-          Подтвердить
+          {ButtonTextTypesEnum.submit}
         </Button>
       </Form.Item>
     </Form>

--- a/src/components/AdminPage/components/AdminPageForm.tsx
+++ b/src/components/AdminPage/components/AdminPageForm.tsx
@@ -5,7 +5,7 @@ import { AdminPanelFormProps } from 'src/interfaces'
 import { StoreValue } from 'rc-field-form/lib/interface'
 import { HandleFinishProps } from './interfaces'
 import { ButtonTextTypesEnum } from 'src/constants'
-import { adminFormMessageTypesEnum } from './constants'
+import { AdminFormMessageTypesEnum } from './constants'
 
 const { Title } = Typography
 
@@ -49,7 +49,7 @@ export const AdminPageForm: FC<AdminPanelFormProps> = ({
                   rules={[
                     {
                       required: true,
-                      message: adminFormMessageTypesEnum.emptyValue,
+                      message: AdminFormMessageTypesEnum.emptyValue,
                     },
                   ]}
                 >

--- a/src/components/AdminPage/components/constants.ts
+++ b/src/components/AdminPage/components/constants.ts
@@ -1,0 +1,3 @@
+export enum adminFormMessageTypesEnum {
+  emptyValue = 'Ввeдите значение',
+}

--- a/src/components/AdminPage/components/constants.ts
+++ b/src/components/AdminPage/components/constants.ts
@@ -1,3 +1,3 @@
-export enum adminFormMessageTypesEnum {
+export enum AdminFormMessageTypesEnum {
   emptyValue = 'Ввeдите значение',
 }

--- a/src/components/AdminPage/components/index.ts
+++ b/src/components/AdminPage/components/index.ts
@@ -1,0 +1,1 @@
+export * from './AdminPageForm'

--- a/src/components/AdminPage/components/interfaces.ts
+++ b/src/components/AdminPage/components/interfaces.ts
@@ -1,0 +1,3 @@
+export interface HandleFinishProps {
+  values: { value: string }[]
+}

--- a/src/components/AdminPage/constants.ts
+++ b/src/components/AdminPage/constants.ts
@@ -1,0 +1,6 @@
+export enum adminFormTypesEnum {
+  teacherFormTitle = 'Преподаватели',
+  teacherFormPlaceholder = 'Ник на Github',
+  repositoryFormTitle = 'Имена репозиториев',
+  repositoryFormPlaceholder = 'Имя репозитория',
+}

--- a/src/components/AdminPage/index.ts
+++ b/src/components/AdminPage/index.ts
@@ -1,0 +1,1 @@
+export * from './AdminPage'

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -1,20 +1,26 @@
-import { Result, Button } from 'antd';
-import {useNavigate} from "react-router-dom";
+import { Result, Button } from 'antd'
+import { useNavigate } from 'react-router-dom'
+import { ErrorPageSubTitleTypesEnum } from './constants'
+import { NavigationPageTypesEnum } from 'src/constants'
+import { ErrorPageStatusTypesEnum } from './constants'
 
 export const ErrorPage = () => {
   const navigate = useNavigate()
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
-    navigate('/')
+    event.preventDefault()
+    navigate(NavigationPageTypesEnum.homePage)
   }
 
   return (
     <Result
-      status="403"
-      title="403"
-      subTitle="Извините, вы не авторизованы для доступа к этой странице."
-      extra={<Button type="primary" onClick={handleClick}>На главную</Button>}
+      status={ErrorPageStatusTypesEnum.notAuthorized}
+      title={ErrorPageStatusTypesEnum.notAuthorized}
+      subTitle={ErrorPageSubTitleTypesEnum.notAuthorized}
+      extra={
+        <Button type="primary" onClick={handleClick}>
+          На главную
+        </Button>
+      }
     />
   )
 }
-

--- a/src/components/ErrorPage/constants.ts
+++ b/src/components/ErrorPage/constants.ts
@@ -1,0 +1,7 @@
+export enum ErrorPageSubTitleTypesEnum {
+  notAuthorized = 'Извините, вы не авторизованы для доступа к этой странице.',
+}
+
+export enum ErrorPageStatusTypesEnum {
+  notAuthorized = '403',
+}

--- a/src/components/ErrorPage/index.ts
+++ b/src/components/ErrorPage/index.ts
@@ -1,0 +1,1 @@
+export * from './ErrorPage'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,11 @@
+export enum NavigationPageTypesEnum {
+  homePage = '/',
+  adminPage = '/admin',
+  studentPage = '/student',
+  loginPage = '/login',
+  adminLoginPage = '/admin-login',
+}
+
+export enum ButtonTextTypesEnum {
+  submit = 'Подтвердить',
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,7 +7,3 @@ export interface LoginCheck {
   username: string
   password: string
 }
-
-export interface AdminPageProps {
-  isAdmin: boolean
-}

--- a/src/store/currentRole/constants.ts
+++ b/src/store/currentRole/constants.ts
@@ -1,0 +1,5 @@
+export enum CurrentRoleTypesEnum {
+  student = 'STUDENT',
+  admin = 'ADMIN',
+  teacher = 'TEACHER',
+}

--- a/src/store/currentRole/events.ts
+++ b/src/store/currentRole/events.ts
@@ -1,0 +1,3 @@
+import { domain } from '../domain'
+
+export const setCurrentRoleEvent = domain.createEvent<string>()

--- a/src/store/currentRole/index.ts
+++ b/src/store/currentRole/index.ts
@@ -1,0 +1,5 @@
+export * from './stores'
+export * from './events'
+export * from './interfaces'
+export * from './constants'
+export * from './init'

--- a/src/store/currentRole/init.ts
+++ b/src/store/currentRole/init.ts
@@ -1,0 +1,3 @@
+import { $currentRole, setCurrentRoleEvent } from './index'
+
+$currentRole.on(setCurrentRoleEvent, (_, role) => role)

--- a/src/store/currentRole/interfaces.ts
+++ b/src/store/currentRole/interfaces.ts
@@ -1,0 +1,5 @@
+export interface AccessByRole {
+  isTeacher: boolean
+  isStudent: boolean
+  isAdmin: boolean
+}

--- a/src/store/currentRole/logic.ts
+++ b/src/store/currentRole/logic.ts
@@ -1,0 +1,8 @@
+import { CurrentRoleTypesEnum } from './constants'
+import { AccessByRole } from './interfaces'
+
+export const accessByRoleMap = (role: string): AccessByRole => ({
+  isTeacher: role === CurrentRoleTypesEnum.teacher,
+  isStudent: role === CurrentRoleTypesEnum.student,
+  isAdmin: role === CurrentRoleTypesEnum.admin,
+})

--- a/src/store/currentRole/stores.ts
+++ b/src/store/currentRole/stores.ts
@@ -1,0 +1,9 @@
+import { Store } from 'effector'
+import { AccessByRole } from './interfaces'
+import { accessByRoleMap } from './logic'
+import { domain } from '../domain'
+
+export const $currentRole = domain.createStore<string>('')
+export const $accessByRole: Store<AccessByRole> = $currentRole.map((role) =>
+  accessByRoleMap(role),
+)

--- a/src/store/currentUser/index.ts
+++ b/src/store/currentUser/index.ts
@@ -1,0 +1,8 @@
+import { createStore, createEvent } from 'effector'
+import { CurrentUserInfo } from '../interfaces'
+
+export const setCurrentUserEvent = createEvent<CurrentUserInfo>()
+
+export const $currentUser = createStore<CurrentUserInfo | null>(null)
+
+$currentUser.on(setCurrentUserEvent, (_, user) => user)

--- a/src/store/currentUser/index.ts
+++ b/src/store/currentUser/index.ts
@@ -1,8 +1,0 @@
-import { createStore, createEvent } from 'effector'
-import { CurrentUserInfo } from '../interfaces'
-
-export const setCurrentUserEvent = createEvent<CurrentUserInfo>()
-
-export const $currentUser = createStore<CurrentUserInfo | null>(null)
-
-$currentUser.on(setCurrentUserEvent, (_, user) => user)

--- a/src/store/domain.ts
+++ b/src/store/domain.ts
@@ -1,0 +1,3 @@
+import { createDomain } from 'effector'
+
+export const domain = createDomain()

--- a/src/store/errorWidget/events.ts
+++ b/src/store/errorWidget/events.ts
@@ -1,0 +1,3 @@
+import { domain } from '../domain'
+
+export const setErrorWarningEvent = domain.createEvent()

--- a/src/store/errorWidget/index.ts
+++ b/src/store/errorWidget/index.ts
@@ -1,0 +1,3 @@
+export * from './stores'
+export * from './events'
+export * from './init'

--- a/src/store/errorWidget/init.ts
+++ b/src/store/errorWidget/init.ts
@@ -1,0 +1,3 @@
+import { $displayErrorWarning, setErrorWarningEvent } from './index'
+
+$displayErrorWarning.on(setErrorWarningEvent, (_) => true)

--- a/src/store/errorWidget/stores.ts
+++ b/src/store/errorWidget/stores.ts
@@ -1,0 +1,3 @@
+import { domain } from '../domain'
+
+export const $displayErrorWarning = domain.createStore<boolean>(false)

--- a/src/store/init.ts
+++ b/src/store/init.ts
@@ -1,0 +1,2 @@
+import './currentRole/'
+import './errorWidget/'

--- a/src/store/interfaces.ts
+++ b/src/store/interfaces.ts
@@ -1,4 +1,0 @@
-export interface CurrentUserInfo {
-  username?: string | null
-  isAdmin?: boolean | null
-}

--- a/src/store/interfaces.ts
+++ b/src/store/interfaces.ts
@@ -1,0 +1,4 @@
+export interface CurrentUserInfo {
+  username?: string | null
+  isAdmin?: boolean | null
+}

--- a/src/utils/checkIsAdmin.ts
+++ b/src/utils/checkIsAdmin.ts
@@ -1,5 +1,6 @@
-import { LoginCheck } from '../interfaces'
+import { LoginCheck } from 'src/interfaces'
 
+//TODO: изменить на проверку по признаку isAdmin, присвоенному юзеру из БД
 export const checkIsAdmin = ({ username, password }: LoginCheck) => {
   const currentUsername = 'admin'
   const currentPassword = 'admin'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "./",
   },
   "include": [
     "src"


### PR DESCRIPTION
@alenasaz @smakhnatkin Всем, привет! Просьба посмотреть PR. Перенес логику в эффектор из всего пока, что касается админа, добавил общий стор - $currentRole и в нет $accessByRole, можно использовать для понимания студент, учитель, админ и дальнейшей навигации доступов и т.д.
Вынес некоторые моменты в constants.ts в enum
Добавил возможность указывать короткие пути для испорта, чтобы до компонента можно было прописать импорт просто через  'src/components/*'
 Для примера: 
```
import { AdminLoginPage } from 'src/components/AdminLoginPage'
```